### PR TITLE
Update postinstall to allow instalation on windows 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=6.9.x"
   },
   "scripts": {
-    "postinstall": "cd ./node_modules/protractor; npm install webdriver-manager@latest; cd ../.. && node_modules/.bin/webdriver-manager update",
+    "postinstall": "npx webdriver-manager update",
     "lint": "node_modules/.bin/eslint *.js tests/**/*.js",
     "test": "node_modules/.bin/protractor tests/protractor.conf.js",
     "patch": "npm version patch -m \"Bumped up package version to %s\" && git push && git push origin --tags && npm publish",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "node-testing-server": "^1.3.1",
     "protractor": "^5.4.2",
     "protractor-cucumber-framework": "^6.1.3"
+  },
+  "peerDependencies": {
+    "protractor": ">= 5.0.0"
   }
 }


### PR DESCRIPTION
This change causes _webdriver-manager update_ to run successfully on _postinstall_, regardless of the operating system used.

fix #78 